### PR TITLE
fix(api-page-generator): quote YAML description for strict parser compatibility

### DIFF
--- a/skills/pages/content/api/SKILL.md
+++ b/skills/pages/content/api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-page-generator
-description: When the user wants to create, optimize, or audit the API introduction/overview page. Also use when the user mentions "API page," "API landing page," "/api page," "API overview," "developer landing," "API marketing," or "API for developers." Note: API documentation (endpoint reference) lives in docs; use docs-page-generator.
+description: 'When the user wants to create, optimize, or audit the API introduction/overview page. Also use when the user mentions "API page," "API landing page," "/api page," "API overview," "developer landing," "API marketing," or "API for developers." Note: API documentation (endpoint reference) lives in docs; use docs-page-generator.'
 metadata:
   version: 1.0.0
 ---


### PR DESCRIPTION
Summary
- Quote the `description` field in `api-page-generator/SKILL.md` to avoid YAML parsing failures in strict parsers.

Problem
- The current `description` value contains colons.
- Some strict YAML parsers, such as Codex, can fail to parse this field correctly when it is left unquoted.

Changes
- Wrap the `description` value in single quotes.
- Preserve the original content while making the file compatible with stricter YAML parsing behavior.

Why this change
- This ensures the skill file can be parsed reliably across different tools and environments.
- The change is minimal and does not alter the meaning of the description.

Validation
- Confirmed the YAML frontmatter remains valid after quoting the value.
- Verified the change is limited to parser compatibility and does not modify skill behavior.